### PR TITLE
Modification of attribute banner to fix issue with launching with qtconsole command

### DIFF
--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -1,3 +1,5 @@
+from subprocess import check_output
+
 from ipykernel.kernelbase import Kernel
 
 from os import unlink, environ
@@ -7,6 +9,8 @@ import imghdr
 import re
 import signal
 import urllib
+
+from traitlets import default, Unicode
 
 from powershell_kernel import subprocess_repl, powershell_proxy
 from powershell_kernel.util import get_powershell
@@ -24,11 +28,14 @@ class PowerShellKernel(Kernel):
         m = version_pat.search(self.banner)
         return m.group(1)
 
-    _banner = None
+    # _banner = None
+    config_file_name = Unicode()
 
-    @property
-    def banner(self):
-        return self._banner
+    banner = Unicode()
+    @default('banner')
+    def _banner_default(self):
+        return check_output(['powershell', '$PSVersionTable.PSVersion']).decode('utf-8')
+        # return self._banner
 
     language_info = {'name': 'powershell',
                      'codemirror_mode': 'shell',

--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -19,6 +19,7 @@ __version__ = '0.0.7'
 
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
 
+
 class PowerShellKernel(Kernel):
     implementation = 'powershell_kernel'
     implementation_version = __version__
@@ -28,10 +29,8 @@ class PowerShellKernel(Kernel):
         m = version_pat.search(self.banner)
         return m.group(1)
 
-    # _banner = None
-    config_file_name = Unicode()
-
     banner = Unicode()
+
     @default('banner')
     def _banner_default(self):
         return check_output(['powershell', '$PSVersionTable.PSVersion']).decode('utf-8')
@@ -44,7 +43,7 @@ class PowerShellKernel(Kernel):
 
     def __init__(self, **kwargs):
         Kernel.__init__(self, **kwargs)
-        
+
         # powershell_command env variable is set by the kernel to allow both powershell and pwsh
         # but on python2 we cannot pass it thru env variable, see https://github.com/vors/jupyter-powershell/issues/7
         # TODO(python2): can we pass it somehow differently and still provide user-picked value on python2?
@@ -61,7 +60,7 @@ class PowerShellKernel(Kernel):
         if not code.strip():
             return {'status': 'ok', 'execution_count': self.execution_count,
                     'payload': [], 'user_expressions': {}}
-        
+
         self.proxy.send_input(code)
         output = self.proxy.get_output()
 


### PR DESCRIPTION
See issue #13 for original bug details.

Updated the PowerShellKernel to use the traitlets model for the attribute banner. I've never used traitlets before, but that what the underlining ipykernel.Kernel is structured off of and what qtconsole.base_frontend_mixin.BaseFrontendMixin's _dispatch() is expecting. 

Implementation:
1. banner's type is set with `banner = Unicode()`
1. banner's default value is provided with:
   ```
   @default('banner')
   def _banner_default(self):
       return check_output(['powershell', '$PSVersionTable.PSVersion']).decode('utf-8')
   ```
1. no other traitlets methods were implemented

Questions for @vors 
1. Do you want me to increase the __version__ in kernel.py? If so I assume 0.0.8, is that correct?
1. Since the traitlets package is now being used, do I need to update any packaging requirements (I've contributed to code installable with pip before - a little out of my depth)?
1. The following packages are marked as unused; do you want me to remove them?
   - os.unlink
   - base64
   - imghdr
   - signal
   - urllib

Other comments:
1. As a result of fixing this the command line argument `--FrontendWidget.banner=...` now works, however this is the JupyterWidget(IPythonWidget)'s banner, not the kernel's banner.