### PR TITLE
Potential fix for cell caching issue

### DIFF
--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -55,7 +55,7 @@ class PowerShellKernel(Kernel):
             return {'status': 'ok', 'execution_count': self.execution_count,
                     'payload': [], 'user_expressions': {}}
         
-        self.proxy.send_input(code)
+        self.proxy.send_input('& { ' + code + ' }')
         output = self.proxy.get_output()
 
         message = {'name': 'stdout', 'text': output}

--- a/powershell_kernel/powershell_proxy.py
+++ b/powershell_kernel/powershell_proxy.py
@@ -26,7 +26,6 @@ class ReplReader(threading.Thread):
 class ReplProxy(object):
     def __init__(self, repl):
         self._repl = repl
-        self.expected_carets = 1
         self._repl_reader = ReplReader(repl)
         # this is a hack to detect when we stop processing this input
         self.send_input('function prompt() {"^"}')
@@ -58,7 +57,6 @@ class ReplProxy(object):
         # https://stackoverflow.com/questions/13229066/how-to-end-a-multi-line-command-in-powershell
         if '\n' in input:
             input += '\n'
-            self.expected_carets = input.count('\n')
 
         self.expected_output_prefix = input.replace('\n', '\n>> ') + '\n'
         self.expected_output_len = len(self.expected_output_prefix)
@@ -93,9 +91,7 @@ class ReplProxy(object):
     def write(self, packet):
         # this is a hack to detect when we stop processing this input
         if packet == '^':
-            self.expected_carets -= 1
-            if self.expected_carets < 1:
-                self.stop_flag = True
+            self.stop_flag = True
             return
         self.output += packet
 


### PR DESCRIPTION
I'm by no means an expert in PowerShell, but did some debugging through the kernel to try and understand the heuristic used to determine when outputs are complete for a given cell.

It looks the kernel looks for a '^' to determine the above condition. The trouble is, for multiline cell sources, it appears that n '^' characters will be returned, where n is the number of lines in the cell's source.

So, I'm just keeping track of the number of lines in the source, and only setting the stop_flag to True when the expected carets goes below 1.