### PR TITLE
Share scope between cells

### DIFF
--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -55,7 +55,7 @@ class PowerShellKernel(Kernel):
             return {'status': 'ok', 'execution_count': self.execution_count,
                     'payload': [], 'user_expressions': {}}
         
-        self.proxy.send_input('& { ' + code + ' }')
+        self.proxy.send_input('. { ' + code + ' }')
         output = self.proxy.get_output()
 
         message = {'name': 'stdout', 'text': output}


### PR DESCRIPTION
Dot source code in cells rather than call, so they execute in the same scope.

Fixes #19