### PR TITLE
Remove 'replace' from install_kernel_spec call

### DIFF
--- a/powershell_kernel/install.py
+++ b/powershell_kernel/install.py
@@ -51,7 +51,7 @@ def install_my_kernel_spec(user=True, prefix=None, powershell_command=None):
         # TODO: Copy resources once they're specified
 
         print('Installing IPython kernel spec')
-        KernelSpecManager().install_kernel_spec(td, 'powershell', user=user, replace=True, prefix=prefix)
+        KernelSpecManager().install_kernel_spec(td, 'powershell', user=user, prefix=prefix)
 
 def _is_root():
     try:


### PR DESCRIPTION
Replace is deprecated, so a warning is emitted on install.

https://github.com/jupyter/jupyter_client/commit/fe09baa18615e30e3db80dea862f884be7b120cf