### PR TITLE
Start powershell in noninteractive mode since stdin isn't currently supported.

### DIFF
--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -46,7 +46,7 @@ class PowerShellKernel(Kernel):
         except:
             powershell_command = get_powershell()
 
-        repl = subprocess_repl.SubprocessRepl([powershell_command, '-noprofile', '-File', '-'])
+        repl = subprocess_repl.SubprocessRepl([powershell_command, '-noninteractive', '-noprofile', '-File', '-'])
         self.proxy = powershell_proxy.ReplProxy(repl)
 
     def do_execute(self, code, silent, store_history=True,


### PR DESCRIPTION
Fixes https://github.com/vors/jupyter-powershell/issues/23

This is just a quick fix for the above. The actual fix would likely involve overriding Read-Host with a custom function. The IPyKernel overwrites raw_input() with its own version to handle prompting for input, so maybe we can call raw_input() via python from a custom Read-Host. If that doesn't work, then we'd need to find a way to integrate the custom Read-Host will all the jupyter socket/messaging logic.

I've also verified that we see an error in the cell output when trying to run functions like Read-Host with this change.
