### PR TITLE
Refactor send_input to handle single line comments and lingering output

### DIFF
--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -61,7 +61,7 @@ class PowerShellKernel(Kernel):
             if not self.proxy:
                 self.__createProxy()
 
-            output = self.proxy.send_input(code)
+            output = self.proxy.run_command(code)
 
             message = {'name': 'stdout', 'text': output}
             self.send_response(self.iopub_socket, 'stream', message)

--- a/powershell_kernel/kernel.py
+++ b/powershell_kernel/kernel.py
@@ -61,8 +61,7 @@ class PowerShellKernel(Kernel):
             if not self.proxy:
                 self.__createProxy()
 
-            self.proxy.send_input('. { ' + code + ' }')
-            output = self.proxy.get_output()
+            output = self.proxy.send_input(code)
 
             message = {'name': 'stdout', 'text': output}
             self.send_response(self.iopub_socket, 'stream', message)

--- a/powershell_kernel/powershell_proxy.py
+++ b/powershell_kernel/powershell_proxy.py
@@ -48,11 +48,11 @@ class ReplProxy(object):
             self.output = ''
             self.stop_flag = False
 
-            # for multiline statements we should send 1 extra new line
+            # Append newline to the original input to handle single line comments on the last line
+            #
+            # Also, for multiline statements we should send 1 extra new line at the end
             # https://stackoverflow.com/questions/13229066/how-to-end-a-multi-line-command-in-powershell
-            input = '. {\n' + input + '\n}'
-            if '\n' in input:
-                input += '\n'
+            input = '. {\n' + input + '\n}\n'
 
             self.expected_output_prefix = input.replace('\n', '\n>> ') + '\n'
             self.expected_output_len = len(self.expected_output_prefix)

--- a/powershell_kernel/powershell_proxy.py
+++ b/powershell_kernel/powershell_proxy.py
@@ -45,6 +45,9 @@ class ReplProxy(object):
     def send_input(self, input):
         self.runCmdLock.acquire()
         try:
+            self.output = ''
+            self.stop_flag = False
+
             # for multiline statements we should send 1 extra new line
             # https://stackoverflow.com/questions/13229066/how-to-end-a-multi-line-command-in-powershell
             input = '. {\n' + input + '\n}'
@@ -60,7 +63,6 @@ class ReplProxy(object):
             while not self.stop_flag:
                 sleep(0.05)
             out = self.output
-            self.output = ''
             self.stop_flag = False
             return out
         finally:

--- a/powershell_kernel/powershell_proxy.py
+++ b/powershell_kernel/powershell_proxy.py
@@ -40,9 +40,9 @@ class ReplProxy(object):
         self.expected_output_len = 0
 
         # this is a hack to detect when we stop processing this input
-        self.send_input('function prompt() {"^"}')
+        self.run_command('function prompt() {"^"}')
 
-    def send_input(self, input):
+    def run_command(self, input):
         self.runCmdLock.acquire()
         try:
             self.output = ''
@@ -62,9 +62,7 @@ class ReplProxy(object):
 
             while not self.stop_flag:
                 sleep(0.05)
-            out = self.output
-            self.stop_flag = False
-            return out
+            return self.output
         finally:
             self.runCmdLock.release()
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/8277
Fixes https://github.com/microsoft/azuredatastudio/issues/7999

There are a couple of things going on in this change. Originally, I intended to fix the above issues with end of line comments by adding a newline to the end of the input text. That solved the comment problem, but then I started seeing issues with cell execution always returning the last result run. Looks like we continually append text to self.output (even after a command "completes"), which messes up the string parsing to get cell outputs later. My solution here was to clear self.output before running a command. 

Since we're modifying self.output in a multithreaded environment, I also decided to combine the input and output functions and add some locking for good measure.

Any ideas for potential edge case tests here would be appreciated.