### PR TITLE
install.py: Allow `--powershell-command` with one of the other parameters

### DIFF
--- a/powershell_kernel/install.py
+++ b/powershell_kernel/install.py
@@ -81,7 +81,7 @@ def main(argv=None):
         help='Install KernelSpec in this prefix',
         default=None
     )
-    prefix_locations.add_argument(
+    parser.add_argument(
         '--powershell-command',
         help='Command to run powershell (by default "powershell" on windows and "pwsh" on unix)',
         default=None


### PR DESCRIPTION
The parameter `--powershell-command` should not be mutually exclusive with the other parameters.

Fixes #42